### PR TITLE
Remove unused fields from User entity and fix id field

### DIFF
--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -1,22 +1,25 @@
-import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryColumn, Column, ManyToOne, BeforeInsert } from 'typeorm';
 import { Owner } from './Owner';
+import { randomUUID } from 'crypto';
 
 @Entity()
 export class User {
-  @PrimaryColumn('text', { default: () => `${5}` })
+  @PrimaryColumn('text')
   id: string;
+
+  @BeforeInsert()
+  setId() {
+    this.id = randomUUID().substring(0, 6);
+  }
 
   @Column()
   name: string;
 
-  @Column('int', { default: 0 })
-  videos_played: number;
-
-  @Column({ nullable: true })
-  last_played_timestamp: Date;
-
   @Column('text', { array: true })
   video_queue: string[];
+
+  @Column('text')
+  ownerId: string;
 
   @ManyToOne(() => Owner, (owner: Owner) => owner.users)
   owner: Owner;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -16,7 +16,11 @@ describe('test that typeorm can connect', () => {
 
   it('should be able to fetch users', async () => {
     const userRepository = handleGetRepository('User');
-    const user = userRepository.create({ name: 'test', video_queue: [] });
+    const ownerRepository = handleGetRepository('Owner');
+    const ownerId = randomUUID();
+    const owner = ownerRepository.create({ id: ownerId });
+    await ownerRepository.save(owner);
+    const user = userRepository.create({ name: 'test', video_queue: [], ownerId });
     await userRepository.save(user);
     const users = await userRepository.find();
     expect(users.length).toBe(1);

--- a/src/migration/1695718059554-user-and-owner.ts
+++ b/src/migration/1695718059554-user-and-owner.ts
@@ -1,14 +1,14 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class UserAndOwnerEntities1695392946597 implements MigrationInterface {
-  name = 'UserAndOwnerEntities1695392946597';
+export class UserAndOwner1695718059554 implements MigrationInterface {
+  name = 'UserAndOwner1695718059554';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `CREATE TABLE "owner" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), CONSTRAINT "PK_8e86b6b9f94aece7d12d465dc0c" PRIMARY KEY ("id"))`,
     );
     await queryRunner.query(
-      `CREATE TABLE "user" ("id" text NOT NULL DEFAULT 5, "name" character varying NOT NULL, "videos_played" integer NOT NULL DEFAULT '0', "last_played_timestamp" TIMESTAMP, "video_queue" text array NOT NULL, "ownerId" uuid, CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`,
+      `CREATE TABLE "user" ("id" text NOT NULL, "name" character varying NOT NULL, "video_queue" text array NOT NULL, "ownerId" uuid NOT NULL, CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`,
     );
     await queryRunner.query(
       `ALTER TABLE "user" ADD CONSTRAINT "FK_6c19ad3671f901796d5a7395e3e" FOREIGN KEY ("ownerId") REFERENCES "owner"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,


### PR DESCRIPTION
There's a little bit of a future coding aspect in the entities right now with the `last_played_timestamp` and `videos_played`. There is no clear roadmap in my head to implement them for the client perhaps ever, so might as well simplify the app at this point and only introduce them in the future when they are actually needed. For what its worth they can be implemented nicely in the client without involving the API anyways. So this PR removes those 2 columns. Also fixes the broken `id` in `User`. It now picks first 6 chars of a random UUID. Why 6? To piggyback on the id nicely for users to join the rooms. With this now enforce a unique 6-character id for users.