### PR TITLE
GET route for getting users for an owner

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -55,7 +55,7 @@ function build(opts = {}) {
       const user = manager.create(User, { ownerId, name, video_queue });
       await manager.save(user);
       return reply.code(201).send({ data: user });
-    }
+    },
   );
 
   app.get<{ Params: Static<typeof UserIdSchema>; Reply: { data: UserSchemaType[] } }>(
@@ -73,7 +73,7 @@ function build(opts = {}) {
       const manager = getEntityManager();
       const users = await manager.find(User, { where: { ownerId: id } });
       return reply.code(200).send({ data: users });
-    }
+    },
   );
 
   return app;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -97,5 +97,5 @@ describe('route-level tests', () => {
     expect(result.length).toBe(2);
     expect(result[0].id).toEqual(user1.id);
     expect(result[1].id).toEqual(user3.id);
-  })
+  });
 });


### PR DESCRIPTION
Route to get users for an owner. The owner's `uuid` acts as a "token" of sorts, to get the users in their room.