### PR TITLE
Endpoint to create an owner

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -136,4 +136,14 @@ describe('route-level tests', () => {
     expect(response.statusCode).toBe(200);
     expect(result).toEqual(user);
   });
+
+  it('should be able to create an owner', async () => {
+    const response = await testHelper.app.inject({
+      method: 'POST',
+      url: '/owner',
+    });
+    const { data: result } = response.json();
+    expect(response.statusCode).toBe(201);
+    expect(result).toHaveProperty('id');
+  });
 });


### PR DESCRIPTION
Owner creation endpoint. Essentially will work as "room" creation for client. Just returns the id, which will act as the owner token to get user data for the room (and create users).